### PR TITLE
Add the debug mode to log details of every request/response in debug mod...

### DIFF
--- a/main.go
+++ b/main.go
@@ -7,10 +7,13 @@ import (
 	"encoding/json"
 	"errors"
 	"io/ioutil"
+	"log"
 	"net"
 	"net/http"
 	"net/http/cookiejar"
+	"net/http/httputil"
 	"net/url"
+	"os"
 	"reflect"
 	"strings"
 	"time"
@@ -45,6 +48,8 @@ type SuperAgent struct {
 	Transport  *http.Transport
 	Cookies    []*http.Cookie
 	Errors     []error
+	Debug      bool
+	logger     *log.Logger
 }
 
 // Used to create a new SuperAgent object.
@@ -63,7 +68,22 @@ func New() *SuperAgent {
 		Transport:  &http.Transport{},
 		Cookies:    make([]*http.Cookie, 0),
 		Errors:     nil,
+		Debug:      false,
+		logger:     log.New(os.Stderr, "[gorequest]", log.LstdFlags),
 	}
+	return s
+}
+
+// Enable the debug mode which logs request/response detail
+func (s *SuperAgent) SetDebug(enable bool) *SuperAgent {
+	s.Debug = enable
+
+	return s
+}
+
+func (s *SuperAgent) SetLogger(logger *log.Logger) *SuperAgent {
+	s.logger = logger
+
 	return s
 }
 
@@ -279,9 +299,9 @@ func (s *SuperAgent) Timeout(timeout time.Duration) *SuperAgent {
 // Set TLSClientConfig for underling Transport.
 // One example is you can use it to disable security check (https):
 //
-// 			gorequest.New().TLSClientConfig(&tls.Config{ InsecureSkipVerify: true}).
-// 				Get("https://disable-security-check.com").
-// 				End()
+//      gorequest.New().TLSClientConfig(&tls.Config{ InsecureSkipVerify: true}).
+//        Get("https://disable-security-check.com").
+//        End()
 //
 func (s *SuperAgent) TLSClientConfig(config *tls.Config) *SuperAgent {
 	s.Transport.TLSClientConfig = config
@@ -519,8 +539,29 @@ func (s *SuperAgent) End(callback ...func(response Response, body string, errs [
 
 	// Set Transport
 	s.Client.Transport = s.Transport
+
+	// Log details of this request
+	if s.Debug {
+		dump, err := httputil.DumpRequest(req, true)
+		s.logger.SetPrefix("[http] ")
+		if err != nil {
+			s.logger.Printf("Error: %s", err.Error())
+		}
+		s.logger.Printf("HTTP Request: %s", string(dump))
+	}
+
 	// Send request
 	resp, err = s.Client.Do(req)
+
+	// Log details of this response
+	if s.Debug {
+		dump, err := httputil.DumpResponse(resp, true)
+		if nil != err {
+			s.logger.Println("Error: ", err.Error())
+		}
+		s.logger.Printf("HTTP Response: %s", string(dump))
+	}
+
 	if err != nil {
 		s.Errors = append(s.Errors, err)
 		return nil, "", s.Errors


### PR DESCRIPTION
Add Debug and logger to the `SuperAgent` struct, enables logs to request/response.

- Add `SetDebug` to enable/disable debug mode
- Add `SetLogger` to enable 3rd integrator leverage his own logger

In debug mode, leverage httputil to dump details of every request/response.