### PR TITLE
Use number when unmarshal json

### DIFF
--- a/main.go
+++ b/main.go
@@ -384,7 +384,9 @@ func (s *SuperAgent) sendStruct(content interface{}) *SuperAgent {
 		s.Errors = append(s.Errors, err)
 	} else {
 		var val map[string]interface{}
-		if err := json.Unmarshal(marshalContent, &val); err != nil {
+		d := json.NewDecoder(bytes.NewBuffer(marshalContent))
+		d.UseNumber()
+		if err := d.Decode(&val); err != nil {
 			s.Errors = append(s.Errors, err)
 		} else {
 			for k, v := range val {
@@ -401,7 +403,9 @@ func (s *SuperAgent) sendStruct(content interface{}) *SuperAgent {
 func (s *SuperAgent) SendString(content string) *SuperAgent {
 	var val map[string]interface{}
 	// check if it is json format
-	if err := json.Unmarshal([]byte(content), &val); err == nil {
+	d := json.NewDecoder(strings.NewReader(content))
+	d.UseNumber()
+	if err := d.Decode(&val); err == nil {
 		for k, v := range val {
 			s.Data[k] = v
 		}


### PR DESCRIPTION
Allow the support of json number.
Example:
```
{
"Name":"Marc",
"id":12423434
}
```