### PR TITLE
Ensure the response Body is reusable

### DIFF
--- a/main.go
+++ b/main.go
@@ -528,6 +528,8 @@ func (s *SuperAgent) End(callback ...func(response Response, body string, errs [
 	defer resp.Body.Close()
 
 	body, _ := ioutil.ReadAll(resp.Body)
+	// Reset resp.Body so it can be use again
+	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
 	bodyString := string(body)
 	// deep copy response to give it to both return and callback func
 	respCallback := *resp

--- a/request_test.go
+++ b/request_test.go
@@ -48,6 +48,21 @@ func TestGet(t *testing.T) {
 		End()
 }
 
+// testing that resp.Body is reusable
+func TestResetBody(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("Just some text"))
+	}))
+
+	defer ts.Close()
+
+	resp, _, _ := New().Get(ts.URL).End()
+	bodyBytes, _ := ioutil.ReadAll(resp.Body)
+	if string(bodyBytes) != "Just some text" {
+		t.Error("Expected to be able to reuse the response body")
+	}
+}
+
 // testing for POST method
 func TestPost(t *testing.T) {
 	const case1_empty = "/"


### PR DESCRIPTION
This PR ensure that we can use "resp.Body" on the response that we get.