### PR TITLE
Fix authorization header

### DIFF
--- a/main.go
+++ b/main.go
@@ -537,11 +537,8 @@ func (s *SuperAgent) End(callback ...func(response Response, body string, errs [
 	req.URL.RawQuery = q.Encode()
 
 	// Add basic auth
-	// Unset if struct is empty
 	if s.BasicAuth != struct{ Username, Password string }{} {
 		req.SetBasicAuth(s.BasicAuth.Username, s.BasicAuth.Password)
-	} else {
-		req.Header.Del("Authorization")
 	}
 
 	// Add cookies


### PR DESCRIPTION
In OAuth 1.0 Protocol, Authorization header will start from "OAuth ".
https://tools.ietf.org/html/rfc5849#page-6

Added SetBasicAuth method is convenient, but it should be able to explicitly specify the Authorization header.