### PR TITLE
Add Param() method to add param to query string

### DIFF
--- a/main.go
+++ b/main.go
@@ -277,6 +277,11 @@ func (s *SuperAgent) queryString(content string) *SuperAgent {
 	return s
 }
 
+func (s *SuperAgent) Param(key string, value string) *SuperAgent {
+		s.QueryData.Add(key, value)
+		return s
+}
+
 func (s *SuperAgent) Timeout(timeout time.Duration) *SuperAgent {
 	s.Transport.Dial = func(network, addr string) (net.Conn, error) {
 		conn, err := net.DialTimeout(network, addr, timeout)

--- a/request_test.go
+++ b/request_test.go
@@ -50,6 +50,28 @@ func TestGet(t *testing.T) {
 		End()
 }
 
+// testing for Param method
+func TestParam(t *testing.T) {
+	paramCode := "123456"
+	paramFields := "f1;f2;f3"
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request){
+			if r.Form.Get("code") != paramCode {
+				t.Errorf("Expected 'code' == %s; got %v", paramCode, r.Form.Get("code"))
+			}
+
+			if r.Form.Get("fields") != paramFields {
+				t.Errorf("Expected 'fields' == %s; got %v", paramFields , r.Form.Get("fields"))
+			}
+	}))
+
+	defer ts.Close()
+
+	New().Get(ts.URL).
+	  Param("code", paramCode).
+		Param("fields", paramFields)
+}
+
 // testing for POST method
 func TestPost(t *testing.T) {
 	const case1_empty = "/"


### PR DESCRIPTION
The Query() method has problems when parse params like this "fields=f1;f2;f3". where the key is 'fields' and the value is 'f1;f2;f3'. after i QueryEscape the param value, it still has some problem.  so i add this method to explicit add param to QueryData.