### PR TITLE
Add http2curl

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ go:
   - 1.2
 install:
   - go get github.com/elazarl/goproxy
+  - go get github.com/moul/http2curl
   - go get golang.org/x/net/publicsuffix
 notifications:
   email:

--- a/main.go
+++ b/main.go
@@ -18,6 +18,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/moul/http2curl"
+
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -53,6 +55,7 @@ type SuperAgent struct {
 	Errors            []error
 	BasicAuth         struct{ Username, Password string }
 	Debug             bool
+	CurlCommand       bool
 	logger            *log.Logger
 }
 
@@ -77,6 +80,7 @@ func New() *SuperAgent {
 		Errors:            nil,
 		BasicAuth:         struct{ Username, Password string }{},
 		Debug:             false,
+		CurlCommand:       false,
 		logger:            log.New(os.Stderr, "[gorequest]", log.LstdFlags),
 	}
 	return s
@@ -85,6 +89,12 @@ func New() *SuperAgent {
 // Enable the debug mode which logs request/response detail
 func (s *SuperAgent) SetDebug(enable bool) *SuperAgent {
 	s.Debug = enable
+	return s
+}
+
+// Enable the curlcommand mode which display a CURL command line
+func (s *SuperAgent) SetCurlCommand(enable bool) *SuperAgent {
+	s.CurlCommand = enable
 	return s
 }
 
@@ -700,6 +710,17 @@ func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, e
 			s.logger.Println("Error:", err)
 		} else {
 			s.logger.Printf("HTTP Request: %s", string(dump))
+		}
+	}
+
+	// Display CURL command line
+	if s.CurlCommand {
+		curl, err := http2curl.GetCurlCommand(req)
+		s.logger.SetPrefix("[curl] ")
+		if err != nil {
+			s.logger.Println("Error:", err)
+		} else {
+			s.logger.Printf("CURL command line: %s", curl)
 		}
 	}
 


### PR DESCRIPTION
Hello,

I added a method to display a CURL command line.
```console
$> cat curl.go
package main

import "github.com/parnurzeal/gorequest"

func main() {
	gorequest.New().Get("https://www.google.com").SetCurlCommand(true).End()
	gorequest.New().Post("https://www.google.com").SetCurlCommand(true).Send("{\"foo\": \"bar\"}").End()
}
$> go run curl.go
[curl] 2015/10/16 12:22:03 CURL command line: curl -X GET https://www.google.com
[curl] 2015/10/16 12:22:03 CURL command line: curl -X POST -d "{\"foo\":\"bar\"}" -H "Content-Type: application/json" https://www.google.com
```