### PR TITLE
Disable transport swap flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -56,6 +56,8 @@ type SuperAgent struct {
 	logger            *log.Logger
 }
 
+var DisableTransportSwap = false
+
 // Used to create a new SuperAgent object.
 func New() *SuperAgent {
 	cookiejarOptions := cookiejar.Options{
@@ -690,7 +692,9 @@ func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, e
 	}
 
 	// Set Transport
-	s.Client.Transport = s.Transport
+	if !DisableTransportSwap {
+		s.Client.Transport = s.Transport
+	}
 
 	// Log details of this request
 	if s.Debug {


### PR DESCRIPTION
DisableTransportSwap flag can be used to block Transport assignment in EndBytes method. After setting it to true, it is possible to use httpmock with gorequest. Example:
gorequest.HttpMockMode = true
httpmock.ActivateNonDefault(client) //the client is a client from SuperAgent instance

//testing code