### PR TITLE
fix nil dereference

### DIFF
--- a/main.go
+++ b/main.go
@@ -677,6 +677,9 @@ func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, e
 			s.Errors = append(s.Errors, err)
 			return nil, nil, s.Errors
 		}
+	default:
+		s.Errors = append(s.Errors, errors.New("No method specified"))
+		return nil, nil, s.Errors
 	}
 
 	for k, v := range s.Header {


### PR DESCRIPTION
```
panic: runtime error: invalid memory address or nil pointer dereference
[signal 0xb code=0x1 addr=0x10 pc=0x61d03]

goroutine 1 [running]:
github.com/parnurzeal/gorequest.(*SuperAgent).EndBytes(0xc820067860, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/Users/quentinperez/go/src/github.com/parnurzeal/gorequest/main.go:590 +0x5d3
github.com/parnurzeal/gorequest.(*SuperAgent).End(0xc820067860, 0x0, 0x0, 0x0, 0xc82000ad80, 0x0, 0x0, 0x0, 0x0, 0x0)
	/Users/quentinperez/go/src/github.com/parnurzeal/gorequest/main.go:536 +0x164
main.main()
	/Users/quentinperez/go/src/github.com/test/main.go:9 +0xaf

goroutine 17 [syscall, locked to thread]:
runtime.goexit()
	/usr/local/Cellar/go/1.5.1/libexec/src/runtime/asm_amd64.s:1696 +0x1
```

Need feedback :)