### PR TITLE
Allow custom methods

### DIFF
--- a/main.go
+++ b/main.go
@@ -123,6 +123,32 @@ func (s *SuperAgent) ClearSuperAgent() {
 	s.Errors = nil
 }
 
+// Just a wrapper to initialize SuperAgent instance by method string
+func (s *SuperAgent) CustomMethod(method, targetUrl string) *SuperAgent {
+	switch method {
+	case POST:
+		return s.Post(targetUrl)
+	case GET:
+		return s.Get(targetUrl)
+	case HEAD:
+		return s.Head(targetUrl)
+	case PUT:
+		return s.Put(targetUrl)
+	case DELETE:
+		return s.Delete(targetUrl)
+	case PATCH:
+		return s.Patch(targetUrl)
+	case OPTIONS:
+		return s.Options(targetUrl)
+	default:
+		s.ClearSuperAgent()
+		s.Method = method
+		s.Url = targetUrl
+		s.Errors = nil
+		return s
+	}
+}
+
 func (s *SuperAgent) Get(targetUrl string) *SuperAgent {
 	s.ClearSuperAgent()
 	s.Method = GET

--- a/main.go
+++ b/main.go
@@ -773,6 +773,8 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 		} else {
 			// TODO: if nothing match, let's return warning here
 		}
+	case "":
+		return nil, errors.New("No method specified")
 	default:
 		req, err = http.NewRequest(s.Method, s.Url, nil)
 		if err != nil {

--- a/main.go
+++ b/main.go
@@ -747,13 +747,11 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 		} else {
 			// TODO: if nothing match, let's return warning here
 		}
-	case GET, HEAD, DELETE, OPTIONS:
+	default:
 		req, err = http.NewRequest(s.Method, s.Url, nil)
 		if err != nil {
 			return nil, err
 		}
-	default:
-		return nil, errors.New("No method specified")
 	}
 
 	for k, v := range s.Header {

--- a/request_test.go
+++ b/request_test.go
@@ -17,6 +17,7 @@ import (
 
 // Test for Make request
 func TestMakeRequest(t *testing.T) {
+	var err error
 	var cases = []struct {
 		m string
 		s *SuperAgent
@@ -32,10 +33,16 @@ func TestMakeRequest(t *testing.T) {
 	}
 
 	for _, c := range cases {
-		_, err := c.s.MakeRequest()
+		_, err = c.s.MakeRequest()
 		if err != nil {
-			t.Errorf("Expected non-nil error for method %q; got %q", c.m, err.Error())
+			t.Errorf("Expected nil error for method %q; got %q", c.m, err.Error())
 		}
+	}
+
+	// empty method should fail
+	_, err = New().CustomMethod("", "/").MakeRequest()
+	if err == nil {
+		t.Errorf("Expected non-nil error for empty method; got %q", err.Error())
 	}
 }
 

--- a/request_test.go
+++ b/request_test.go
@@ -28,6 +28,7 @@ func TestMakeRequest(t *testing.T) {
 		{PATCH, New().Patch("/")},
 		{DELETE, New().Delete("/")},
 		{OPTIONS, New().Options("/")},
+		{"TRACE", New().CustomMethod("TRACE", "/")}, // valid HTTP 1.1 method, see W3C RFC 2616
 	}
 
 	for _, c := range cases {


### PR DESCRIPTION
Simply as it is. There is no practical sence or need to have some hardcoded subset of HTTP methods, so I allowed to use any, but gracefully used existing methods for shorthand `CustomMethod` function.