### PR TITLE
Expose equivalent curl command.

### DIFF
--- a/main.go
+++ b/main.go
@@ -806,3 +806,17 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 
 	return req, nil
 }
+
+// AsCurlCommand returns a string representing the runnable `curl' command
+// version of the request.
+func (s *SuperAgent) AsCurlCommand() (string, error) {
+	req, err := s.MakeRequest()
+	if err != nil {
+		return "", err
+	}
+	cmd, err := http2curl.GetCurlCommand(req)
+	if err != nil {
+		return "", err
+	}
+	return cmd.String(), nil
+}

--- a/request_test.go
+++ b/request_test.go
@@ -695,3 +695,22 @@ func TestPlainText(t *testing.T) {
 		Send(text).
 		End()
 }
+
+func TestAsCurlCommand(t *testing.T) {
+	var (
+		endpoint = "http://github.com/parnurzeal/gorequest"
+		jsonData = `{"here": "is", "some": {"json": ["data"]}}`
+	)
+
+	request := New().Timeout(10*time.Second).Put(endpoint).Set("Content-Type", "application/json").Send(jsonData)
+
+	curlComand, err := request.AsCurlCommand()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := fmt.Sprintf(`curl -X PUT -d %q -H "Content-Type: application/json" %v`, strings.Replace(jsonData, " ", "", -1), endpoint)
+	if curlComand != expected {
+		t.Fatalf("\nExpected curlCommand=%v\n   but actual result=%v", expected, curlComand)
+	}
+}


### PR DESCRIPTION
Make equivalent curl command available through `AsCurlCommand()' method.

Includes corresponding unit-test.