### PR TITLE
EndStruct feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,24 @@ The callbacks work the same way as with `End`, except that a byte array is used 
 resp, bodyBytes, errs := gorequest.New().Get("http://example.com/").EndBytes()
 ```
 
+## EndStruct
+
+We now have EndStruct to use when you want the body as struct.
+
+The callbacks work the same way as with `End`, except that a struct is used instead of a string.
+
+Supposing the URL **http://example.com/** returns the body `{"hey":"you"}`
+
+```go
+heyYou struct {
+  Hey string `json:"hey"`
+}
+
+var heyYou heyYou
+
+resp, errs := gorequest.New().Get("http://example.com/").EndStruct(&heyYou)
+```
+
 ## Debug
 
 For debugging, GoRequest leverages `httputil` to dump details of every request/response. (Thanks to @dafang)

--- a/README.md
+++ b/README.md
@@ -205,7 +205,7 @@ heyYou struct {
 
 var heyYou heyYou
 
-resp, errs := gorequest.New().Get("http://example.com/").EndStruct(&heyYou)
+resp, _, errs := gorequest.New().Get("http://example.com/").EndStruct(&heyYou)
 ```
 
 ## Debug

--- a/main.go
+++ b/main.go
@@ -655,7 +655,7 @@ func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response
 	err := json.Unmarshal(body, &v)
 	if err != nil {
 		s.Errors = append(s.Errors, err)
-		return nil, body, s.Errors
+		return resp, body, s.Errors
 	}
 	respCallback := *resp
 	if len(callback) != 0 {

--- a/main.go
+++ b/main.go
@@ -647,21 +647,21 @@ func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, e
 }
 
 // EndStruct should be used when you want the body as a struct. The callbacks work the same way as with `End`, except that a struct is used instead of a string.
-func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response, v interface{}, errs []error)) (Response, []error) {
+func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response, v interface{}, body []byte, errs []error)) (Response, []byte, []error) {
 	resp, body, errs := s.EndBytes()
 	if errs != nil {
-		return nil, errs
+		return nil, body, errs
 	}
 	err := json.Unmarshal(body, &v)
 	if err != nil {
 		s.Errors = append(s.Errors, err)
-		return nil, s.Errors
+		return nil, body, s.Errors
 	}
 	respCallback := *resp
 	if len(callback) != 0 {
-		callback[0](&respCallback, v, s.Errors)
+		callback[0](&respCallback, v, body, s.Errors)
 	}
-	return resp, nil
+	return resp, body, nil
 }
 
 func (s *SuperAgent) getResponseBytes() (Response, []byte, []error) {

--- a/request_test.go
+++ b/request_test.go
@@ -478,7 +478,7 @@ func TestEndStruct(t *testing.T) {
 
 	// Callback.
 	{
-		resp, errs := New().Get(ts.URL).EndStruct(func(resp Response, v interface{}, errs []error) {
+		resp, bodyBytes, errs := New().Get(ts.URL).EndStruct(func(resp Response, v interface{}, body []byte, errs []error) {
 			if len(errs) > 0 {
 				t.Fatalf("Unexpected errors: %s", errs)
 			}
@@ -489,6 +489,9 @@ func TestEndStruct(t *testing.T) {
 				resBytes, _ := json.Marshal(resStruct)
 				t.Errorf("Expected body=%s, actual bodyBytes=%s", serverOutput, string(resBytes))
 			}
+			if !reflect.DeepEqual(body, serverOutput) {
+				t.Errorf("Expected bodyBytes=%s, actual bodyBytes=%s", serverOutput, string(body))
+			}
 		})
 		if len(errs) > 0 {
 			t.Fatalf("Unexpected errors: %s", errs)
@@ -496,20 +499,26 @@ func TestEndStruct(t *testing.T) {
 		if resp.StatusCode != 200 {
 			t.Fatalf("Expected StatusCode=200, actual StatusCode=%v", resp.StatusCode)
 		}
+		if !reflect.DeepEqual(bodyBytes, serverOutput) {
+			t.Errorf("Expected bodyBytes=%s, actual bodyBytes=%s", serverOutput, string(bodyBytes))
+		}
 	}
 
 	// No callback.
 	{
-		resp, errs := New().Get(ts.URL).EndStruct(&resStruct)
+		resp, bodyBytes, errs := New().Get(ts.URL).EndStruct(&resStruct)
 		if len(errs) > 0 {
 			t.Errorf("Unexpected errors: %s", errs)
 		}
 		if resp.StatusCode != 200 {
 			t.Errorf("Expected StatusCode=200, actual StatusCode=%v", resp.StatusCode)
 		}
-		if reflect.DeepEqual(expStruct, resStruct) {
+		if !reflect.DeepEqual(expStruct, resStruct) {
 			resBytes, _ := json.Marshal(resStruct)
 			t.Errorf("Expected body=%s, actual bodyBytes=%s", serverOutput, string(resBytes))
+		}
+		if !reflect.DeepEqual(bodyBytes, serverOutput) {
+			t.Errorf("Expected bodyBytes=%s, actual bodyBytes=%s", serverOutput, string(bodyBytes))
 		}
 	}
 }


### PR DESCRIPTION
# EndStruct

EndStruct is to use when you want the body as struct.

The callbacks work the same way as with `End`, except that a struct is used instead of a string.

Supposing the URL **http://example.com/** returns the body `{"hey":"you"}`

```go
heyYou struct {
  Hey string `json:"hey"`
}

var heyYou heyYou

resp, _, errs := gorequest.New().Get("http://example.com/").EndStruct(&heyYou)
```