### PR TITLE
issue #87: supporting ptr type for structs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # Folders
 _obj
 _test
+.idea
 
 # Architecture specific extensions/prefixes
 *.[568vq]

--- a/main.go
+++ b/main.go
@@ -493,6 +493,15 @@ func (s *SuperAgent) Send(content interface{}) *SuperAgent {
 		}
 		s.SendSlice(slice)
 	default:
+		if v.Kind() == reflect.Ptr {
+			switch v.Elem().Kind() {
+			case reflect.Struct:
+				s.SendStruct(v.Interface())
+				// TODO: Add here more cases for pointers to slices, numbers, etc...
+			}
+			return s
+		}
+
 		// TODO: leave default for handling other types in the future such as number, byte, etc...
 		// TODO: Add support for slice and array
 	}


### PR DESCRIPTION
Added support for reflect.Ptr in Send Method.

See issue #87 