### PR TITLE
Bug duplicate queryparams

### DIFF
--- a/main.go
+++ b/main.go
@@ -571,23 +571,25 @@ func (s *SuperAgent) SendString(content string) *SuperAgent {
 			default:
 				s.BounceToRawString = true
 			}
-		} else if formVal, err := url.ParseQuery(content); err == nil {
-			for k, _ := range formVal {
-				// make it array if already have key
-				if val, ok := s.Data[k]; ok {
-					var strArray []string
-					strArray = append(strArray, formVal.Get(k))
-					// check if previous data is one string or array
-					switch oldValue := val.(type) {
-					case []string:
-						strArray = append(strArray, oldValue...)
-					case string:
-						strArray = append(strArray, oldValue)
+		} else if formData, err := url.ParseQuery(content); err == nil {
+			for k, formValues := range formData {
+				for _, formValue := range formValues {
+					// make it array if already have key
+					if val, ok := s.Data[k]; ok {
+						var strArray []string
+						strArray = append(strArray, string(formValue))
+						// check if previous data is one string or array
+						switch oldValue := val.(type) {
+						case []string:
+							strArray = append(strArray, oldValue...)
+						case string:
+							strArray = append(strArray, oldValue)
+						}
+						s.Data[k] = strArray
+					} else {
+						// make it just string if does not already have same key
+						s.Data[k] = formValue
 					}
-					s.Data[k] = strArray
-				} else {
-					// make it just string if does not already have same key
-					s.Data[k] = formVal.Get(k)
 				}
 			}
 			s.TargetType = "form"

--- a/main.go
+++ b/main.go
@@ -349,9 +349,11 @@ func (s *SuperAgent) queryString(content string) *SuperAgent {
 			s.QueryData.Add(k, v)
 		}
 	} else {
-		if queryVal, err := url.ParseQuery(content); err == nil {
-			for k, _ := range queryVal {
-				s.QueryData.Add(k, queryVal.Get(k))
+		if queryData, err := url.ParseQuery(content); err == nil {
+			for k, queryValues := range queryData {
+				for _, queryValue := range queryValues {
+					s.QueryData.Add(k, string(queryValue))
+				}
 			}
 		} else {
 			s.Errors = append(s.Errors, err)

--- a/request_test.go
+++ b/request_test.go
@@ -265,6 +265,7 @@ func TestPost(t *testing.T) {
 	const case21_send_byte_char_pointer = "/send_byte_char_pointer"
 	const case22_send_byte_int = "/send_byte_int"
 	const case22_send_byte_int_pointer = "/send_byte_int_pointer"
+	const case23_send_duplicate_query_params = "/send_duplicate_query_params"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check method is PATCH before going to check other features
@@ -377,11 +378,26 @@ func TestPost(t *testing.T) {
 				t.Error("Expected Body with \"true\"", "| but got", string(body))
 			}
 		case case20_send_byte_char, case21_send_byte_char_pointer, case22_send_byte_int, case22_send_byte_int_pointer:
-			t.Logf("case %v ", case16_send_bool_pointer)
+			t.Logf("case %v ", r.URL.Path)
 			defer r.Body.Close()
 			body, _ := ioutil.ReadAll(r.Body)
 			if string(body) != "71" {
 				t.Error("Expected Body with \"71\"", "| but got", string(body))
+			}
+		case case23_send_duplicate_query_params:
+			t.Logf("case %v ", case23_send_duplicate_query_params)
+			defer r.Body.Close()
+			body, _ := ioutil.ReadAll(r.Body)
+			sbody := string(body)
+			if sbody != "param=4&param=3&param=2&param=1"   {
+				t.Error("Expected Body \"param=4&param=3&param=2&param=1\"", "| but got", sbody)
+			}
+			values, _ := url.ParseQuery(sbody)
+			if len(values["param"]) != 4 {
+				t.Error("Expected Body with 4 params", "| but got", sbody)
+			}
+			if values["param"][0] != "4" || values["param"][1] != "3" || values["param"][2] != "2" || values["param"][3] != "1" {
+				t.Error("Expected Body with 4 params and values", "| but got", sbody)
 			}
 		}
 	}))
@@ -540,6 +556,12 @@ func TestPost(t *testing.T) {
 
 	New().Post(ts.URL + case22_send_byte_int_pointer).
 		Send(&iByte).
+		End()
+
+	New().Post(ts.URL + case23_send_duplicate_query_params).
+		Send("param=1").
+		Send("param=2").
+		Send("param=3&param=4").
 		End()
 }
 


### PR DESCRIPTION
I discovered a "bug" or more an inconsistency between sending duplicate params with multiple method calls and single method call. As example considering:

```go
New().Post("http://httpbin.org/post").
		Send("param=1").
		Send("param=2").
		End()
```

and 

```go
New().Post("http://httpbin.org/post").
		Send("param=1&param=2").
		End()
```

I would expect same behaviour here, but in second code fragment the second `param=2` gets lost. The same applies at the `Query()`-Method.

In case this isn't the desired behaviour, i made a bugfix for this. Feel free to merge or closed this pull request. :)