### PR TITLE
Add option to prevent SuperAgent from clearing

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -74,6 +74,7 @@ type SuperAgent struct {
 		Attempt         int
 		Enable          bool
 	}
+	DoNotClearSuperAgent bool
 }
 
 var DisableTransportSwap = false
@@ -130,6 +131,9 @@ func (s *SuperAgent) SetLogger(logger *log.Logger) *SuperAgent {
 
 // Clear SuperAgent data for another new request.
 func (s *SuperAgent) ClearSuperAgent() {
+	if s.DoNotClearSuperAgent {
+		return
+	}
 	s.Url = ""
 	s.Method = ""
 	s.Header = make(map[string]string)


### PR DESCRIPTION
Fixes #106,

Add a default-to-false option that prevents SuperAgent from clearing
in the case of requests.

Signed-off-by: Olivier himself@otremblay.com
