### PR TITLE
Additional test for query + request body behaviour

### DIFF
--- a/gorequest_test.go
+++ b/gorequest_test.go
@@ -348,7 +348,7 @@ func TestPost(t *testing.T) {
 	const case22_send_byte_int = "/send_byte_int"
 	const case22_send_byte_int_pointer = "/send_byte_int_pointer"
 	const case23_send_duplicate_query_params = "/send_duplicate_query_params"
-    const case24_send_query_and_request_body = "/send_query_and_request_body"
+	const case24_send_query_and_request_body = "/send_query_and_request_body"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check method is POST before going to check other features
@@ -482,17 +482,17 @@ func TestPost(t *testing.T) {
 			if values["param"][0] != "4" || values["param"][1] != "3" || values["param"][2] != "2" || values["param"][3] != "1" {
 				t.Error("Expected Body with 4 params and values", "| but got", sbody)
 			}
-        case case24_send_query_and_request_body:
-            t.Logf("case %v ", case24_send_query_and_request_body)
-            defer r.Body.Close()
-            body, _ := ioutil.ReadAll(r.Body)
+		case case24_send_query_and_request_body:
+			t.Logf("case %v ", case24_send_query_and_request_body)
+			defer r.Body.Close()
+			body, _ := ioutil.ReadAll(r.Body)
 			sbody := string(body)
-            if sbody != `{"name":"jkbbwr"}` {
+			if sbody != `{"name":"jkbbwr"}` {
 				t.Error(`Expected Body "{"name":"jkbbwr"}"`, "| but got", sbody)
 			}
 
-            v := r.URL.Query()
-            if v["test"][0] != "true" {
+			v := r.URL.Query()
+			if v["test"][0] != "true" {
 				t.Error("Expected test:true", "| but got", v["test"][0])
 			}
 		}
@@ -647,8 +647,10 @@ func TestPost(t *testing.T) {
 		Send("param=3&param=4").
 		End()
 
-    data24 := struct{Name string `json:"name"`}{"jkbbwr"}
-    New().Post(ts.URL + case24_send_query_and_request_body).
+	data24 := struct {
+		Name string `json:"name"`
+	}{"jkbbwr"}
+	New().Post(ts.URL + case24_send_query_and_request_body).
 		Query("test=true").
 		Send(data24).
 		End()
@@ -1602,8 +1604,8 @@ func TestGetSetCookies(t *testing.T) {
 	defer ts.Close()
 
 	New().Get(ts.URL).AddCookies([]*http.Cookie{
-		&http.Cookie{Name: "API-Cookie-Name1", Value: "api-cookie-value1"},
-		&http.Cookie{Name: "API-Cookie-Name2", Value: "api-cookie-value2"},
+		{Name: "API-Cookie-Name1", Value: "api-cookie-value1"},
+		{Name: "API-Cookie-Name2", Value: "api-cookie-value2"},
 	}).End()
 }
 

--- a/gorequest_test.go
+++ b/gorequest_test.go
@@ -348,6 +348,7 @@ func TestPost(t *testing.T) {
 	const case22_send_byte_int = "/send_byte_int"
 	const case22_send_byte_int_pointer = "/send_byte_int_pointer"
 	const case23_send_duplicate_query_params = "/send_duplicate_query_params"
+    const case24_send_query_and_request_body = "/send_query_and_request_body"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check method is POST before going to check other features
@@ -480,6 +481,19 @@ func TestPost(t *testing.T) {
 			}
 			if values["param"][0] != "4" || values["param"][1] != "3" || values["param"][2] != "2" || values["param"][3] != "1" {
 				t.Error("Expected Body with 4 params and values", "| but got", sbody)
+			}
+        case case24_send_query_and_request_body:
+            t.Logf("case %v ", case24_send_query_and_request_body)
+            defer r.Body.Close()
+            body, _ := ioutil.ReadAll(r.Body)
+			sbody := string(body)
+            if sbody != `{"name":"jkbbwr"}` {
+				t.Error(`Expected Body "{"name":"jkbbwr"}"`, "| but got", sbody)
+			}
+
+            v := r.URL.Query()
+            if v["test"][0] != "true" {
+				t.Error("Expected test:true", "| but got", v["test"][0])
 			}
 		}
 	}))
@@ -631,6 +645,12 @@ func TestPost(t *testing.T) {
 		Send("param=1").
 		Send("param=2").
 		Send("param=3&param=4").
+		End()
+
+    data24 := struct{Name string `json:"name"`}{"jkbbwr"}
+    New().Post(ts.URL + case24_send_query_and_request_body).
+		Query("test=true").
+		Send(data24).
 		End()
 }
 
@@ -1709,7 +1729,7 @@ func TestAsCurlCommand(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	expected := fmt.Sprintf(`curl -X PUT -d %q -H "Content-Type: application/json" '%v'`, strings.Replace(jsonData, " ", "", -1), endpoint)
+	expected := fmt.Sprintf(`curl -X 'PUT' -d '%v' -H 'Content-Type: application/json' '%v'`, strings.Replace(jsonData, " ", "", -1), endpoint)
 	if curlComand != expected {
 		t.Fatalf("\nExpected curlCommand=%v\n   but actual result=%v", expected, curlComand)
 	}


### PR DESCRIPTION
adds test to show that the behaviour in parnurzeal/gorequest#29 is already supported by gorequest, and updates the TestAsCurlCommand test to pass with the latest version of http2curl

The issue that was brought up appears to be now supported by gorequest, this adds an explicit test to show the behaviour can be accomplished using a slightly modified version of the original proposed API

``` go
data := struct{Name string `json:"name"`}{"jkbbwr"}
resp, body, errs := request.Post("http://example.com").
  Set("Notes","gorequest is coming!").
  Query("test=true").
  Send(data).
  End()
```
