### PR TITLE
added Dump method to enable manual request dumping

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1025,13 +1025,7 @@ func (s *SuperAgent) getResponseBytes() (Response, []byte, []error) {
 
 	// Log details of this request
 	if s.Debug {
-		dump, err := httputil.DumpRequest(req, true)
-		s.logger.SetPrefix("[http] ")
-		if err != nil {
-			s.logger.Println("Error:", err)
-		} else {
-			s.logger.Printf("HTTP Request: %s", string(dump))
-		}
+		s.Dump()
 	}
 
 	// Display CURL command line
@@ -1225,4 +1219,20 @@ func (s *SuperAgent) AsCurlCommand() (string, error) {
 		return "", err
 	}
 	return cmd.String(), nil
+}
+
+// Dump creates the required request and logs it's contents.
+func (s *SuperAgent) Dump() {
+	req, err := s.MakeRequest()
+	if err != nil {
+		s.logger.Println("Error:", err)
+	}
+
+	dump, err := httputil.DumpRequest(req, true)
+	s.logger.SetPrefix("[http] ")
+	if err != nil {
+		s.logger.Println("Error:", err)
+	} else {
+		s.logger.Printf("HTTP Request: %s", string(dump))
+	}
 }


### PR DESCRIPTION
Created `Dump` method that allows user to dump the request at any time.

This is usable while debugging.