### PR TITLE
Allow bodies with all methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ go:
   - 1.3
   - 1.2
 install:
-  - go get ./...
+  - go get -t -v ./...
 notifications:
   email:
     recipients: parnurzeal@gmail.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,7 @@ go:
   - 1.3
   - 1.2
 install:
-  - go get github.com/elazarl/goproxy
-  - go get github.com/moul/http2curl
-  - go get golang.org/x/net/publicsuffix
+  - go get ./...
 notifications:
   email:
     recipients: parnurzeal@gmail.com

--- a/gorequest.go
+++ b/gorequest.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"crypto/tls"
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"log"
 	"net"
@@ -18,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/pkg/errors"
 
 	"mime/multipart"
 

--- a/gorequest.go
+++ b/gorequest.go
@@ -1091,112 +1091,106 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 		err error
 	)
 
-	switch s.Method {
-	case POST, PUT, PATCH:
-		if s.TargetType == "json" {
-			// If-case to give support to json array. we check if
-			// 1) Map only: send it as json map from s.Data
-			// 2) Array or Mix of map & array or others: send it as rawstring from s.RawString
-			var contentJson []byte
-			if s.BounceToRawString {
-				contentJson = []byte(s.RawString)
-			} else if len(s.Data) != 0 {
-				contentJson, _ = json.Marshal(s.Data)
-			} else if len(s.SliceData) != 0 {
-				contentJson, _ = json.Marshal(s.SliceData)
-			}
-			contentReader := bytes.NewReader(contentJson)
-			req, err = http.NewRequest(s.Method, s.Url, contentReader)
-			if err != nil {
-				return nil, err
-			}
-			req.Header.Set("Content-Type", "application/json")
-		} else if s.TargetType == "form" || s.TargetType == "form-data" || s.TargetType == "urlencoded" {
-			var contentForm []byte
-			if s.BounceToRawString || len(s.SliceData) != 0 {
-				contentForm = []byte(s.RawString)
-			} else {
-				formData := changeMapToURLValues(s.Data)
-				contentForm = []byte(formData.Encode())
-			}
-			contentReader := bytes.NewReader(contentForm)
-			req, err = http.NewRequest(s.Method, s.Url, contentReader)
-			if err != nil {
-				return nil, err
-			}
-			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-		} else if s.TargetType == "text" {
-			req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
-			req.Header.Set("Content-Type", "text/plain")
-		} else if s.TargetType == "xml" {
-			req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
-			req.Header.Set("Content-Type", "application/xml")
-		} else if s.TargetType == "multipart" {
-
-			var buf bytes.Buffer
-			mw := multipart.NewWriter(&buf)
-
-			if s.BounceToRawString {
-				fieldName, ok := s.Header["data_fieldname"]
-				if !ok {
-					fieldName = "data"
-				}
-				fw, _ := mw.CreateFormField(fieldName)
-				fw.Write([]byte(s.RawString))
-			}
-
-			if len(s.Data) != 0 {
-				formData := changeMapToURLValues(s.Data)
-				for key, values := range formData {
-					for _, value := range values {
-						fw, _ := mw.CreateFormField(key)
-						fw.Write([]byte(value))
-					}
-				}
-			}
-
-			if len(s.SliceData) != 0 {
-				fieldName, ok := s.Header["json_fieldname"]
-				if !ok {
-					fieldName = "data"
-				}
-				// copied from CreateFormField() in mime/multipart/writer.go
-				h := make(textproto.MIMEHeader)
-				fieldName = strings.Replace(strings.Replace(fieldName, "\\", "\\\\", -1), `"`, "\\\"", -1)
-				h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"`, fieldName))
-				h.Set("Content-Type", "application/json")
-				fw, _ := mw.CreatePart(h)
-				contentJson, err := json.Marshal(s.SliceData)
-				if err != nil {
-					return nil, err
-				}
-				fw.Write(contentJson)
-			}
-
-			// add the files
-			if len(s.FileData) != 0 {
-				for _, file := range s.FileData {
-					fw, _ := mw.CreateFormFile(file.Fieldname, file.Filename)
-					fw.Write(file.Data)
-				}
-			}
-
-			// close before call to FormDataContentType ! otherwise its not valid multipart
-			mw.Close()
-
-			req, err = http.NewRequest(s.Method, s.Url, &buf)
-			req.Header.Set("Content-Type", mw.FormDataContentType())
-		} else {
-			// let's return an error instead of an nil pointer exception here
-			return nil, errors.New("TargetType '" + s.TargetType + "' could not be determined")
-		}
-	case "":
+	if s.Method == "" {
 		return nil, errors.New("No method specified")
-	default:
-		req, err = http.NewRequest(s.Method, s.Url, nil)
+	}
+
+	if s.TargetType == "json" {
+		// If-case to give support to json array. we check if
+		// 1) Map only: send it as json map from s.Data
+		// 2) Array or Mix of map & array or others: send it as rawstring from s.RawString
+		var contentJson []byte
+		if s.BounceToRawString {
+			contentJson = []byte(s.RawString)
+		} else if len(s.Data) != 0 {
+			contentJson, _ = json.Marshal(s.Data)
+		} else if len(s.SliceData) != 0 {
+			contentJson, _ = json.Marshal(s.SliceData)
+		}
+		contentReader := bytes.NewReader(contentJson)
+		req, err = http.NewRequest(s.Method, s.Url, contentReader)
 		if err != nil {
 			return nil, err
 		}
+		req.Header.Set("Content-Type", "application/json")
+	} else if s.TargetType == "form" || s.TargetType == "form-data" || s.TargetType == "urlencoded" {
+		var contentForm []byte
+		if s.BounceToRawString || len(s.SliceData) != 0 {
+			contentForm = []byte(s.RawString)
+		} else {
+			formData := changeMapToURLValues(s.Data)
+			contentForm = []byte(formData.Encode())
+		}
+		contentReader := bytes.NewReader(contentForm)
+		req, err = http.NewRequest(s.Method, s.Url, contentReader)
+		if err != nil {
+			return nil, err
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	} else if s.TargetType == "text" {
+		req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
+		req.Header.Set("Content-Type", "text/plain")
+	} else if s.TargetType == "xml" {
+		req, err = http.NewRequest(s.Method, s.Url, strings.NewReader(s.RawString))
+		req.Header.Set("Content-Type", "application/xml")
+	} else if s.TargetType == "multipart" {
+
+		var buf bytes.Buffer
+		mw := multipart.NewWriter(&buf)
+
+		if s.BounceToRawString {
+			fieldName, ok := s.Header["data_fieldname"]
+			if !ok {
+				fieldName = "data"
+			}
+			fw, _ := mw.CreateFormField(fieldName)
+			fw.Write([]byte(s.RawString))
+		}
+
+		if len(s.Data) != 0 {
+			formData := changeMapToURLValues(s.Data)
+			for key, values := range formData {
+				for _, value := range values {
+					fw, _ := mw.CreateFormField(key)
+					fw.Write([]byte(value))
+				}
+			}
+		}
+
+		if len(s.SliceData) != 0 {
+			fieldName, ok := s.Header["json_fieldname"]
+			if !ok {
+				fieldName = "data"
+			}
+			// copied from CreateFormField() in mime/multipart/writer.go
+			h := make(textproto.MIMEHeader)
+			fieldName = strings.Replace(strings.Replace(fieldName, "\\", "\\\\", -1), `"`, "\\\"", -1)
+			h.Set("Content-Disposition", fmt.Sprintf(`form-data; name="%s"`, fieldName))
+			h.Set("Content-Type", "application/json")
+			fw, _ := mw.CreatePart(h)
+			contentJson, err := json.Marshal(s.SliceData)
+			if err != nil {
+				return nil, err
+			}
+			fw.Write(contentJson)
+		}
+
+		// add the files
+		if len(s.FileData) != 0 {
+			for _, file := range s.FileData {
+				fw, _ := mw.CreateFormFile(file.Fieldname, file.Filename)
+				fw.Write(file.Data)
+			}
+		}
+
+		// close before call to FormDataContentType ! otherwise its not valid multipart
+		mw.Close()
+
+		req, err = http.NewRequest(s.Method, s.Url, &buf)
+		req.Header.Set("Content-Type", mw.FormDataContentType())
+	} else {
+		// let's return an error instead of an nil pointer exception here
+		return nil, errors.New("TargetType '" + s.TargetType + "' could not be determined")
 	}
 
 	for k, v := range s.Header {


### PR DESCRIPTION
Hi!

We've used your great library to build our [API library](https://github.com/chartmogul/chartmogul-go). But now, when I was testing it, I realized the `DELETE` method wasn't sending body to server.
I realize it may not be the best design, but the [RFC doesn't prohibit it](https://www.w3.org/Protocols/rfc2616/rfc2616-sec9.html) and well, the library shouldn't be making design decisions for its users, right?

So I removed the switch to allow bodies for all methods, not just `POST, PUT, PATCH`.

The tests are passing. I've tried a few empty-bodied requests and they work as before.

I replaced `"errors"` with `"github.com/pkg/errors"`, because of stack tracing etc. I've included it in this PR.

Also, I recommend trying golint, got 120 warnings there. 

Thank you for including this in the master as soon as possible.