### PR TITLE
nil buffer fix

### DIFF
--- a/gorequest_test.go
+++ b/gorequest_test.go
@@ -1063,6 +1063,7 @@ func TestMultipartRequest(t *testing.T) {
 		Type("multipart").
 		Query("query1=test").
 		Query("query2=test").
+		Send("foo").
 		End()
 
 	New().Post(ts.URL + case5_send_struct).


### PR DESCRIPTION
Fixed nil reader content regression introduced with PR #129.

- Don't allow buffers with nil contents to be passed to `http.NewRequest` constructor.

  Fixes errors like:

    Get https://[SOME-WEBSITE]: stream error: stream ID 1; REFUSED_STREAM
