### PR TITLE
add a logger interface, and make the "logging" more flexible

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -67,7 +67,7 @@ type SuperAgent struct {
 	BasicAuth         struct{ Username, Password string }
 	Debug             bool
 	CurlCommand       bool
-	logger            *log.Logger
+	logger            Logger
 	Retryable         struct {
 		RetryableStatus []int
 		RetryerTime     time.Duration
@@ -124,7 +124,7 @@ func (s *SuperAgent) SetCurlCommand(enable bool) *SuperAgent {
 	return s
 }
 
-func (s *SuperAgent) SetLogger(logger *log.Logger) *SuperAgent {
+func (s *SuperAgent) SetLogger(logger Logger) *SuperAgent {
 	s.logger = logger
 	return s
 }

--- a/logger.go
+++ b/logger.go
@@ -1,0 +1,7 @@
+package gorequest
+
+type Logger interface {
+	SetPrefix(string)
+	Printf(format string, v ...interface{})
+	Println(v ...interface{})
+}


### PR DESCRIPTION
I have a customized "logging" module, and want to make gorequests be able to utilize it instead of using the default go log struct.

In the meantime, the default logger remains the same.