### PR TITLE
Fix typo in doc

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -906,7 +906,7 @@ func changeMapToURLValues(data map[string]interface{}) url.Values {
 // For example:
 //
 //    resp, body, errs := gorequest.New().Get("http://www.google.com").End()
-//    if (errs != nil) {
+//    if errs != nil {
 //      fmt.Println(errs)
 //    }
 //    fmt.Println(resp, body)


### PR DESCRIPTION
Parenthesis are not required around the condition in a if-statement in Go.

Great lib BTW! 👍 