### PR TITLE
Don't infer Content-Type when set explicitly

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1268,8 +1268,7 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 			req.Host = vals[0]
 		}
 	}
-
-	if len(contentType) != 0 {
+	if len(contentType) != 0 && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", contentType)
 	}
 

--- a/gorequest.go
+++ b/gorequest.go
@@ -1268,6 +1268,9 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 			req.Host = vals[0]
 		}
 	}
+
+	// https://github.com/parnurzeal/gorequest/issues/164
+	// Don't infer the content type header if an overrride is already provided.
 	if len(contentType) != 0 && req.Header.Get("Content-Type") == "" {
 		req.Header.Set("Content-Type", contentType)
 	}


### PR DESCRIPTION
Amends https://github.com/parnurzeal/gorequest/pull/154
Fixes https://github.com/parnurzeal/gorequest/issues/164