### PR TITLE
Handle error in byte stream (failed transfer of a chunk)

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1118,10 +1118,12 @@ func (s *SuperAgent) getResponseBytes() (Response, []byte, []error) {
 		}
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	// Reset resp.Body so it can be use again
 	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-
+	if err != nil {
+		return nil, nil, []error{err}
+	}
 	return resp, body, nil
 }
 


### PR DESCRIPTION
**tldr; fixing large files transfer error is not reported**

My file transfers end successfully with partially transferred files.
To distinguish HTTP errors from transfer layer errors I've tested for `res == nil`, because (my logic went) such error won't return `Response`.
But then I investigated further and found [this explicitly ignored error](https://github.com/parnurzeal/gorequest/blob/develop/gorequest.go#L1121) (red flag). The `Body` is a stream that - for longer data - is chunked into multiple packets. Any of these can fail to transfer. Resuming aside, the program must know when this error happened.