### PR TITLE
Allow non-string values for JSON strings fed to Query()

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -454,10 +454,14 @@ func (s *SuperAgent) queryStruct(content interface{}) *SuperAgent {
 }
 
 func (s *SuperAgent) queryString(content string) *SuperAgent {
-	var val map[string]string
+	var val map[string]interface{}
 	if err := json.Unmarshal([]byte(content), &val); err == nil {
 		for k, v := range val {
-			s.QueryData.Add(k, v)
+			if v == nil {
+				s.QueryData.Add(k, "null")
+			} else {
+				s.QueryData.Add(k, fmt.Sprintf("%v", v))
+			}
 		}
 	} else {
 		if queryData, err := url.ParseQuery(content); err == nil {

--- a/gorequest.go
+++ b/gorequest.go
@@ -375,21 +375,23 @@ func (s *SuperAgent) Type(typeStr string) *SuperAgent {
 	return s
 }
 
-// Query function accepts either json string or strings which will form a query-string in url of GET method or body of POST method.
-// For example, making "/search?query=bicycle&size=50x50&weight=20kg" using GET method:
+// Query function accepts either a JSON string or strings which will form a query-string in url of GET method or body of POST method; alternatively you may provide a struct or a map.
+// For example, making "/search?query=bicycle&size=50x50&weight=20kg&count=2&working=false" using GET method:
 //
 //      gorequest.New().
 //        Get("/search").
-//        Query(`{ query: 'bicycle' }`).
-//        Query(`{ size: '50x50' }`).
-//        Query(`{ weight: '20kg' }`).
+//        Query(`{ "query": "bicycle" }`).
+//        Query(`{ "size": "50x50" }`).
+//        Query(`{ "weight": "20kg" }`).
+//        Query(`{ "count": 2 }`).
+//        Query(`{ "working": false }`).
 //        End()
 //
 // Or you can put multiple json values:
 //
 //      gorequest.New().
 //        Get("/search").
-//        Query(`{ query: 'bicycle', size: '50x50', weight: '20kg' }`).
+//        Query(`{ "query": "bicycle", "size": "50x50", "weight": "20kg", "count":2, "working": false }`).
 //        End()
 //
 // Strings are also acceptable:
@@ -398,6 +400,7 @@ func (s *SuperAgent) Type(typeStr string) *SuperAgent {
 //        Get("/search").
 //        Query("query=bicycle&size=50x50").
 //        Query("weight=20kg").
+//        Query("count=2&working=false").
 //        End()
 //
 // Or even Mixed! :)
@@ -405,7 +408,29 @@ func (s *SuperAgent) Type(typeStr string) *SuperAgent {
 //      gorequest.New().
 //        Get("/search").
 //        Query("query=bicycle").
-//        Query(`{ size: '50x50', weight:'20kg' }`).
+//        Query(`{ "size": "50x50", "weight": "20kg", "count": 2, "working": false }`).
+//        End()
+//
+// A map:
+//
+//      gorequest.New().
+//        Get("/search").
+//        Query(map[string]interface{}{"query": "bicycle", "size": "50x50", "weight": "20kg", "count": 2, "working": false}).
+//        End()
+//
+// Or a struct:
+
+//      type Bicycle struct {
+// 	        Query   string
+// 	        Size    string
+// 	        Weight  string
+// 	        Count   int
+// 	        Working bool
+//      }
+//
+//      gorequest.New().
+//        Get("/search").
+//        Query(Bicycle{"bicycle", "50x50", "20kg", 2, false}).
 //        End()
 //
 func (s *SuperAgent) Query(content interface{}) *SuperAgent {


### PR DESCRIPTION
This change allows non-string values (number, bool, null) to be used by the Query() method when it is fed a JSON-format string.

For example, this is now possible:

``Query(`{ "query": "bicycle", "size": "50x50", "weight": "20kg", "count":2, "working": false }`)``

`count` and `working` are using non-string values, which was not possible previously as queryString() was trying to json.Unmarshal() to a `map[string]string` instead of a `map[string]interface{}`.