### PR TITLE
Allow socks5 support on proxy settings

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -30,6 +30,7 @@ import (
 	"path/filepath"
 
 	"github.com/moul/http2curl"
+	"golang.org/x/net/proxy"
 	"golang.org/x/net/publicsuffix"
 )
 
@@ -496,6 +497,12 @@ func (s *SuperAgent) Proxy(proxyUrl string) *SuperAgent {
 		s.Errors = append(s.Errors, err)
 	} else if proxyUrl == "" {
 		s.Transport.Proxy = nil
+	} else if proxyUrl[:6] == "socks5" {
+		socks5Dialer, err := proxy.FromURL(parsedProxyUrl, proxy.Direct)
+		if err != nil {
+			s.Errors = append(s.Errors, err)
+		}
+		s.Transport = &http.Transport{Dial: socks5Dialer.Dial}
 	} else {
 		s.Transport.Proxy = http.ProxyURL(parsedProxyUrl)
 	}

--- a/gorequest.go
+++ b/gorequest.go
@@ -497,7 +497,7 @@ func (s *SuperAgent) Proxy(proxyUrl string) *SuperAgent {
 		s.Errors = append(s.Errors, err)
 	} else if proxyUrl == "" {
 		s.Transport.Proxy = nil
-	} else if proxyUrl[:6] == "socks5" {
+	} else if strings.ToLower(proxyUrl[:6]) == "socks5" {
 		socks5Dialer, err := proxy.FromURL(parsedProxyUrl, proxy.Direct)
 		if err != nil {
 			s.Errors = append(s.Errors, err)


### PR DESCRIPTION
This change allows socks5 on proxy settings by creating an socks5 Dialer on transport layer. Also, this is case insensitive, so user can set proxy by declaring in any case.