### PR TITLE
EndStruct: Allow empty body not to return json failure

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1024,10 +1024,12 @@ func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response
 	if errs != nil {
 		return nil, body, errs
 	}
-	err := json.Unmarshal(body, &v)
-	if err != nil {
-		s.Errors = append(s.Errors, err)
-		return resp, body, s.Errors
+	if len(body) != 0 {
+		err := json.Unmarshal(body, &v)
+		if err != nil {
+			s.Errors = append(s.Errors, err)
+			return resp, body, s.Errors
+		}
 	}
 	respCallback := *resp
 	if len(callback) != 0 {


### PR DESCRIPTION
Sometimes servers could send back empty body, and when that happens currently, `EndStruct()` returns a json decoding error which can be confusing.
Instead we could just avoid to unmarshall the body and leave the struct nil.
(I have an app that, depending on the api version, returns a message or not. Fixing that would allow me to have both version of the client work properly and handle real errors coming from bad server output)