### PR TITLE
callback works if a request end with error

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -977,23 +977,25 @@ func (s *SuperAgent) End(callback ...func(response Response, body string, errs [
 // EndBytes should be used when you want the body as bytes. The callbacks work the same way as with `End`, except that a byte array is used instead of a string.
 func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, errs []error)) (Response, []byte, []error) {
 	var (
-		errs []error
-		resp Response
-		body []byte
+		errs         []error
+		resp         Response
+		body         []byte
+		respCallback http.Response
 	)
 
 	for {
 		resp, body, errs = s.getResponseBytes()
 		if errs != nil {
-			return nil, nil, errs
+			break
 		}
+
 		if s.isRetryableRequest(resp) {
 			resp.Header.Set("Retry-Count", strconv.Itoa(s.Retryable.Attempt))
+			respCallback = *resp
 			break
 		}
 	}
 
-	respCallback := *resp
 	if len(callback) != 0 {
 		callback[0](&respCallback, body, s.Errors)
 	}


### PR DESCRIPTION
NewRequest().End(callbackFun)

if an error occur in a request, the func will return without calling the callback function in which i could have handled the error:

```
for {
 		resp, body, errs = s.getResponseBytes()
 		if errs != nil {
                         // here returns
			return nil, nil, errs
 		}
                 ...
 	}

```


so we may change the `return` to `break`, and return the result at the bottom of the whole function like this:

```
func (s *SuperAgent) EndBytes(callback ...func(response Response, body []byte, errs []error)) (Response, []byte, []error) {
	var (
		errs         []error
		resp         Response
		body         []byte
		respCallback http.Response
	)

	for {
		resp, body, errs = s.getResponseBytes()
		if errs != nil {
			break
		}

		if s.isRetryableRequest(resp) {
			resp.Header.Set("Retry-Count", strconv.Itoa(s.Retryable.Attempt))
			respCallback = *resp
			break
		}
	}

	if len(callback) != 0 {
		callback[0](&respCallback, body, s.Errors)
	}
	return resp, body, nil
}
```