### PR TITLE
Handle error in byte stream (failed transfer of a chunk)

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -1118,10 +1118,12 @@ func (s *SuperAgent) getResponseBytes() (Response, []byte, []error) {
 		}
 	}
 
-	body, _ := ioutil.ReadAll(resp.Body)
+	body, err := ioutil.ReadAll(resp.Body)
 	// Reset resp.Body so it can be use again
 	resp.Body = ioutil.NopCloser(bytes.NewBuffer(body))
-
+	if err != nil {
+		return nil, nil, []error{err}
+	}
 	return resp, body, nil
 }
 


### PR DESCRIPTION
Let's see if it builds this time?

https://golang.org/pkg/io/ioutil/#example_ReadAll
>A successful call returns err == nil, not err == EOF.

=> should check error in all cases.

A year ago I encountered a problem with transferring large CSV files using gorequest - I got only part of the file without error being returned and failed late in the program on parsing errors. Since then we switched to a different API (hurray) that doesn't have this quirk, but still.