### PR TITLE
add context support

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -3,6 +3,7 @@ package gorequest
 
 import (
 	"bytes"
+	"context"
 	"crypto/tls"
 	"encoding/json"
 	"io"
@@ -91,6 +92,7 @@ type SuperAgent struct {
 	Retryable            superAgentRetryable
 	DoNotClearSuperAgent bool
 	isClone              bool
+	context				 context.Context
 }
 
 var DisableTransportSwap = false
@@ -123,6 +125,7 @@ func New() *SuperAgent {
 		CurlCommand:       false,
 		logger:            log.New(os.Stderr, "[gorequest]", log.LstdFlags),
 		isClone:           false,
+		context:           nil,
 	}
 	// disable keep alives by default, see this issue https://github.com/parnurzeal/gorequest/issues/75
 	s.Transport.DisableKeepAlives = true
@@ -234,6 +237,7 @@ func (s *SuperAgent) Clone() *SuperAgent {
 		Retryable:            copyRetryable(s.Retryable),
 		DoNotClearSuperAgent: true,
 		isClone:              true,
+		context: 			  s.context,
 	}
 	return clone
 }
@@ -280,6 +284,7 @@ func (s *SuperAgent) ClearSuperAgent() {
 	s.TargetType = TypeJSON
 	s.Cookies = make([]*http.Cookie, 0)
 	s.Errors = nil
+	s.context = nil
 }
 
 // Just a wrapper to initialize SuperAgent instance by method string
@@ -1120,6 +1125,14 @@ func contains(respStatus int, statuses []int) bool {
 	return false
 }
 
+func (s *SuperAgent) Context(ctx context.Context) *SuperAgent{
+	if ctx == nil {
+		panic("context can't be nil")
+	}
+	s.context = ctx
+	return s
+}
+
 // EndStruct should be used when you want the body as a struct. The callbacks work the same way as with `End`, except that a struct is used instead of a string.
 func (s *SuperAgent) EndStruct(v interface{}, callback ...func(response Response, v interface{}, body []byte, errs []error)) (Response, []byte, []error) {
 	resp, body, errs := s.EndBytes()
@@ -1361,6 +1374,11 @@ func (s *SuperAgent) MakeRequest() (*http.Request, error) {
 	if req, err = http.NewRequest(s.Method, s.Url, contentReader); err != nil {
 		return nil, err
 	}
+
+	if s.context != nil {
+		req = req.WithContext(s.context)
+	}
+
 	for k, vals := range s.Header {
 		for _, v := range vals {
 			req.Header.Add(k, v)

--- a/gorequest_test.go
+++ b/gorequest_test.go
@@ -2,6 +2,7 @@ package gorequest
 
 import (
 	"bytes"
+	"context"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
@@ -2567,5 +2568,25 @@ func TestSetDebugByEnvironmentVar(t *testing.T) {
 
 	if len(buf.String()) > 0 {
 		t.Fatalf("\nExpected gorequest not to log request and response object if GOREQUEST_DEBUG is not set.")
+	}
+}
+
+func TestContenxt(t *testing.T) {
+	// requesting a long connection which block this requst for a time,
+	// but 2 seconds later we unable to hold ourself back and force close it
+	ctx, cancel := context.WithCancel(context.Background())
+	go New().Context(ctx).Get("http://127.0.0.1:8080/foo").EndBytes(func(response Response, body []byte, errs []error) {
+
+
+		if len(errs) > 0 {
+			fmt.Printf("%+v\n", errs[0])
+		}
+		fmt.Println(string(body))
+	})
+
+	select {
+	case <-time.After(2 * time.Second):
+		fmt.Println("cancel...")
+		cancel()
 	}
 }


### PR DESCRIPTION
Hi, I'm a newbie gopher and I like your gorequest  lib so much, now I'm using it in production env, tks for your work!
recently, when I write code with gorequest, I found it wasn't support the Context type, which provided by go itself and greatly benefit http connection control.   net.http support context, and I found a sample way to add this support to gorequest. I hope you can check my code, and provide some suggestion, thks very much! 