### PR TITLE
Cancel case conversion of keywords

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -541,7 +541,6 @@ func (s *SuperAgent) queryStruct(content interface{}) *SuperAgent {
 			s.Errors = append(s.Errors, err)
 		} else {
 			for k, v := range val {
-				k = strings.ToLower(k)
 				var queryVal string
 				switch t := v.(type) {
 				case string:


### PR DESCRIPTION
The parameters of the POST method need to distinguish the case of the parameter name.