### PR TITLE
不转换,保持原始大小写

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -541,7 +541,6 @@ func (s *SuperAgent) queryStruct(content interface{}) *SuperAgent {
 			s.Errors = append(s.Errors, err)
 		} else {
 			for k, v := range val {
-				k = strings.ToLower(k)
 				var queryVal string
 				switch t := v.(type) {
 				case string:


### PR DESCRIPTION
转换参数大小写后,有可能致使接收方无法解析参数