### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ Compared to our GoRequest version, JSON is for sure a default. So, it turns out 
 ```go
 request := gorequest.New()
 resp, body, errs := request.Post("http://example.com").
-  Set("Notes","gorequst is coming!").
+  Set("Notes","gorequest is coming!").
   Send(`{"name":"backy", "species":"dog"}`).
   End()
 ```


### PR DESCRIPTION
Added a missing "e" in a string