### PR TITLE
Add possibility to use fieldname file (not change it to file1, file2,…

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -951,8 +951,11 @@ func (s *SuperAgent) SendFile(file interface{}, args ...interface{}) *SuperAgent
 		if len(args) == 1 {
 			return s.SendFile(v.Elem().Interface(), args[0])
 		}
-		if len(args) >= 2 {
+		if len(args) == 2 {
 			return s.SendFile(v.Elem().Interface(), args[0], args[1])
+		}
+		if len(args) == 3 {
+			return s.SendFile(v.Elem().Interface(), args[0], args[1], args[2])
 		}
 		return s.SendFile(v.Elem().Interface())
 	default:

--- a/gorequest.go
+++ b/gorequest.go
@@ -872,7 +872,8 @@ type File struct {
 //        End()
 //
 // The second optional argument (third argument overall) is the fieldname in the multipart/form-data request. It defaults to fileNUMBER (eg. file1), where number is ascending and starts counting at 1.
-// So if you send multiple files, the fieldnames will be file1, file2, ... unless it is overwritten. If fieldname is set to "file" it will be automatically set to fileNUMBER, where number is the greatest exsiting number+1.
+// So if you send multiple files, the fieldnames will be file1, file2, ... unless it is overwritten. If fieldname is set to "file" it will be automatically set to fileNUMBER, where number is the greatest exsiting number+1 unless
+// a third argument skipFileNumbering is provided and true.
 //
 //      b, _ := ioutil.ReadFile("./example_file.ext")
 //      gorequest.New().
@@ -881,18 +882,34 @@ type File struct {
 //        SendFile(b, "", "my_custom_fieldname"). // filename left blank, will become "example_file.ext"
 //        End()
 //
-func (s *SuperAgent) SendFile(file interface{}, args ...string) *SuperAgent {
+func (s *SuperAgent) SendFile(file interface{}, args ...interface{}) *SuperAgent {
 
 	filename := ""
 	fieldname := "file"
+	skipFileNumbering := false
 
-	if len(args) >= 1 && len(args[0]) > 0 {
-		filename = strings.TrimSpace(args[0])
+	if len(args) >= 1 {
+		argFilename := fmt.Sprintf("%v", args[0])
+		if len(argFilename) > 0 {
+			filename = strings.TrimSpace(argFilename)
+		}
 	}
-	if len(args) >= 2 && len(args[1]) > 0 {
-		fieldname = strings.TrimSpace(args[1])
+
+	if len(args) >= 2 {
+		argFieldname := fmt.Sprintf("%v", args[1])
+		if len(argFieldname) > 0 {
+			fieldname = strings.TrimSpace(argFieldname)
+		}
 	}
-	if fieldname == "file" || fieldname == "" {
+
+	if len(args) >= 3 {
+		argSkipFileNumbering := reflect.ValueOf(args[2])
+		if argSkipFileNumbering.Type().Name() == "bool" {
+			skipFileNumbering = argSkipFileNumbering.Interface().(bool)
+		}
+	}
+
+	if (fieldname == "file" && !skipFileNumbering) || fieldname == "" {
 		fieldname = "file" + strconv.Itoa(len(s.FileData)+1)
 	}
 

--- a/gorequest_test.go
+++ b/gorequest_test.go
@@ -1225,6 +1225,7 @@ func TestMultipartRequest(t *testing.T) {
 	const case25_send_file_with_name_with_spaces_only = "/send_file_with_name_with_spaces_only"
 	const case26_send_file_with_fieldname_with_spaces = "/send_file_with_fieldname_with_spaces"
 	const case27_send_file_with_fieldname_with_spaces_only = "/send_file_with_fieldname_with_spaces_only"
+	const case28_send_file_with_file_as_fieldname_and_skip_file_numbering_true = "/send_file_with_file_as_fieldname_and_skip_file_numbering_true"
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// check method is POST before going to check other features
@@ -1538,6 +1539,16 @@ func TestMultipartRequest(t *testing.T) {
 				t.Error("Expected Filename:LICENSE", "| but got", r.MultipartForm.File["my_fieldname"][0].Filename)
 			}
 			checkFile(t, r.MultipartForm.File["my_fieldname"][0])
+		case case28_send_file_with_file_as_fieldname_and_skip_file_numbering_true:
+			if len(r.MultipartForm.File) != 1 {
+				t.Error("Expected length of files:[] == 1", "| but got", len(r.MultipartForm.File))
+			}
+			if val, ok := r.MultipartForm.File["file"]; !ok {
+				t.Error("Expected file with key: file", "| but got ", val)
+			}
+			if r.MultipartForm.File["file"][0].Filename != "LICENSE" {
+				t.Error("Expected Filename:LICENSE", "| but got", r.MultipartForm.File["file"][0].Filename)
+			}
 		}
 
 	}))
@@ -1735,6 +1746,11 @@ func TestMultipartRequest(t *testing.T) {
 	New().Post(ts.URL+case27_send_file_with_fieldname_with_spaces_only).
 		Type("multipart").
 		SendFile(osFile, "", "   ").
+		End()
+
+	New().Post(ts.URL+case28_send_file_with_file_as_fieldname_and_skip_file_numbering_true).
+		Type("multipart").
+		SendFile(osFile, "", "file", true).
 		End()
 }
 


### PR DESCRIPTION
Currenty, when we call `SendFile(b, "file", "filename")`, `"file"` will be changed to `"file1", "file2", etc.`. This is not good if we are dealing with a server that require a `multipart` with a `fieldname` equal to `file`.

I added an optional `bool` parameter `skipFileNumbering` in `SendFile` which disable adding those numbers

I am adding the possibility to skip appending numbers but without breaking compatibility or changing behavior of any existing code.