### PR TITLE
Remove converting query keys to lower case

### DIFF
--- a/gorequest.go
+++ b/gorequest.go
@@ -536,7 +536,6 @@ func (s *SuperAgent) queryStruct(content interface{}) *SuperAgent {
 			s.Errors = append(s.Errors, err)
 		} else {
 			for k, v := range val {
-				k = strings.ToLower(k)
 				var queryVal string
 				switch t := v.(type) {
 				case string:


### PR DESCRIPTION
Fix https://github.com/parnurzeal/gorequest/issues/253

When the input is a struct, you can change the `key` by setting a struct tag: 
```go
payload := struct {
	  Foo string `json:"foo"`	// <- HERE
	  QWE string `json:"QWE"`
}{
	  Foo: "bar",
	  QWE: "rty",
}

gorequest.New().Get("http://localhost:1234").Query(payload).End()
// GET /?foo=bar&QWE=rty
```

For map input, it will also set the correct keys.
```go
gorequest.New().Get("http://localhost:1234/").Query(map[string]string{"Foo": "bar", "QWE": "rty"}).End()
// GET /?Foo=bar&QWE=rty
```